### PR TITLE
csp whitelist and extra fields for Helcim.js processing

### DIFF
--- a/Helcim/HelcimAPI/etc/csp_whitelist.xml
+++ b/Helcim/HelcimAPI/etc/csp_whitelist.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<csp_whitelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Csp:etc/csp_whitelist.xsd">
+    <policies>
+        <policy id="script-src">
+            <values>
+                <value id="helcim" type="host">https://secure.myhelcim.com</value>
+            </values>
+        </policy>
+        <policy id="connect-src">
+            <values>
+                <value id="helcim" type="host">https://secure.myhelcim.com</value>
+            </values>
+        </policy>
+    </policies>
+</csp_whitelist>

--- a/Helcim/HelcimAPI/view/frontend/web/js/view/payment/method-renderer/helcim_api.js
+++ b/Helcim/HelcimAPI/view/frontend/web/js/view/payment/method-renderer/helcim_api.js
@@ -9,9 +9,10 @@ define(
         'jquery',
         'Magento_Payment/js/model/credit-card-validation/credit-card-data',
         'Magento_Payment/js/model/credit-card-validation/credit-card-number-validator',
-        'mage/translate'
+        'mage/translate',
+	'Magento_Checkout/js/model/quote'
     ],
-    function (Component, $, creditCardData, cardNumberValidator, $t) {
+    function (Component, $, creditCardData, cardNumberValidator, $t, quote) {
 
         return Component.extend({
             defaults: {
@@ -187,10 +188,20 @@ define(
                         var cvv = document.getElementsByName('payment[cc_cid]')[0].value;
                         var customerId = window.checkoutConfig.customerData.id;
 
+			var amount = quote.totals().base_grand_total;
+
+			var billing = quote.billingAddress();
+			
+			var cardHolderName = billing.firstname + " " + billing.lastname			 
+			var cardHolderAddress = ""
+			for (street_index in billing.street) cardHolderAddress += billing.street[street_index] + "\n"
+			cardHolderAddress += billing.city + ", " + billing.region
+			var cardHolderPostalCode = billing.postcode
+
                         if (expiryMonth.length == 1) { expiryMonth = '0' + expiryMonth; }
 
                         // CREATE HIDDEN FORM FOR CARD TOKENIZATION
-                        document.querySelector('footer').innerHTML += '<form style="display:none;" name="helcimForm2" id="helcimForm2" method="POST"><div style="display:none;" id="helcimResults"></div><input type="hidden" id="token" value="' + jsToken + '"> <input type="hidden" id="language" value="en"> <input type="hidden" id="dontSubmit" value="1"> <input type="hidden" id="test" value="'+testMode+'"> <input type="hidden" id="xml" value="1"><input type="hidden" id="cardNumber" value="' + cardNumber + '"><br/> <input type="hidden" id="cardExpiryMonth" value="' + expiryMonth + '"> <input type="hidden" id="cardExpiryYear" value="' + expiryYear.slice(-2) + '"><br/> <input type="hidden" id="cardCVV" value="' + cvv + '"><br/> <input type="hidden" id="amount" value="0"><br/> <input type="hidden" id="customerCode" value="' + customerId + '"><br/> </form>';
+                        document.querySelector('footer').innerHTML += '<form style="display:none;" name="helcimForm2" id="helcimForm2" method="POST"><div style="display:none;" id="helcimResults"></div><input type="hidden" id="token" value="' + jsToken + '"> <input type="hidden" id="language" value="en"> <input type="hidden" id="dontSubmit" value="1"> <input type="hidden" id="test" value="'+testMode+'"> <input type="hidden" id="xml" value="1"><input type="hidden" id="cardNumber" value="' + cardNumber + '"><br/> <input type="hidden" id="cardExpiryMonth" value="' + expiryMonth + '"> <input type="hidden" id="cardExpiryYear" value="' + expiryYear.slice(-2) + '"><br/> <input type="hidden" id="cardCVV" value="' + cvv + '"><br/> <input type="hidden" id="amount" value="' + amount + '"><br/> <input type="hidden" id="customerCode" value="' + customerId + '"><br/> <input type="hidden" id="cardHolderName" value="' + cardHolderName + '"><br/> <input type="hidden" id="cardHolderPostalCode" value="' + cardHolderPostalCode + '"><br/><input type="hidden" id="cardHolderAddress" value="' + cardHolderAddress+ '"><br/></form>';
 
                         // CLEAR CREDIT CARD DATA
                         document.getElementsByName('payment[cc_number]')[0].value = '';

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Requires Magento 2.x installation: http://devdocs.magento.com/
 
 In order to utilize the Helcim Commerce API, you must enter your Helcim Commerce account ID as well as an API token in the Magento plugin setup. For instructions on generating an API token with the correct permissions, please visit: https://www.helcim.com/support/article/627-helcim-commerce-api-enabling-api-access/
 
+When using this plugin with a Helcim.js token, set the Helcim.js configuration in Helcim Hub to "Card Verify" mode. When using Helcim.js, this plugin first runs a verification transaction to tokenize the card, then initiates a preauthorization with the tokenized card.
+
 ## Magento Plugin Installation
 
 - Copy and paste the Helcim folder in the <your Magento2 install dir>/app/code Directory.


### PR DESCRIPTION
Apologies for the rushed pull request, I don't know if these changes will help most Magento users. I added a few instructions to README.md based on my experience (not knowing that the Helcim.js configuration should be set to Card Verify),

Added cardholder name and address as well as amount fields for processing with Helcim.js in card purchase mode, but didn't get as far as preventing a preauth afterwards since this plugin expects the Helcim.js configuration to be in verify mode. In the end I switched to verify mode and it's working now. Without another system to test on, I will probably leave my configuration like this even though it's probably not as well integrated as it could be.

Also added csp_whitelist xml to make chrome happy.